### PR TITLE
Remove python3 as a dependency

### DIFF
--- a/rtc-helpers.php
+++ b/rtc-helpers.php
@@ -1,0 +1,102 @@
+<?php
+/**
+ * CLI helpers for rtc-test.sh — no WordPress required.
+ *
+ * Usage:
+ *   php rtc-helpers.php capture-sanitize <fixture.json>
+ *   php rtc-helpers.php replay-extract   <fixture.json>
+ */
+
+$command = $argv[1] ?? '';
+$file    = $argv[2] ?? '';
+
+// Use realpath() + is_file() rather than file_exists() — the latter resolves
+// PHP stream wrappers (php://filter, phar://) which would bypass this guard.
+$real = '' !== $file ? realpath( $file ) : false;
+if ( false === $real || ! is_file( $real ) ) {
+	fwrite( STDERR, "Usage: php rtc-helpers.php <capture-sanitize|replay-extract> <fixture.json>\n" );
+	exit( 1 );
+}
+$file = $real;
+
+switch ( $command ) {
+	case 'capture-sanitize':
+		rtctest_capture_sanitize( $file );
+		break;
+	case 'replay-extract':
+		rtctest_replay_extract( $file );
+		break;
+	default:
+		fwrite( STDERR, "Unknown command: {$command}\n" );
+		exit( 1 );
+}
+
+// -----------------------------------------------------------------------------
+
+function rtctest_capture_sanitize( string $file ) {
+	$data = json_decode( file_get_contents( $file ), true );
+	if ( null === $data ) {
+		fwrite( STDERR, 'capture-sanitize: ' . json_last_error_msg() . "\n" );
+		exit( 1 );
+	}
+	$frames_in  = $data['frames'] ?? [];
+	$frames_out = [];
+
+	foreach ( $frames_in as $frame ) {
+		$rooms     = $frame['request']['rooms'] ?? [];
+		$post_room = null;
+		foreach ( $rooms as $r ) {
+			if ( strpos( $r['room'] ?? '', 'postType/post:' ) === 0 ) {
+				$post_room = $r;
+				break;
+			}
+		}
+		if ( null === $post_room ) {
+			continue;
+		}
+		$frames_out[] = [
+			'n'          => $frame['n'] ?? count( $frames_out ) + 1,
+			'elapsed_ms' => $frame['elapsed_ms'] ?? 0,
+			'client_id'  => $frame['client_id'] ?? 0,
+			'request'    => [ 'rooms' => [ [
+				'room'      => 'postType/post:0',
+				'client_id' => $post_room['client_id'] ?? ( $frame['client_id'] ?? 0 ),
+				'awareness' => new stdClass(),
+				'after'     => 0,
+				'updates'   => $post_room['updates'] ?? [],
+			] ] ],
+		];
+	}
+
+	$out = [
+		'session_id'  => $data['session_id'] ?? '',
+		'frame_count' => count( $frames_out ),
+		'frames'      => $frames_out,
+	];
+
+	echo json_encode( $out, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE ) . "\n";
+}
+
+function rtctest_replay_extract( string $file ) {
+	$data = json_decode( file_get_contents( $file ), true );
+	if ( null === $data ) {
+		fwrite( STDERR, 'replay-extract: ' . json_last_error_msg() . "\n" );
+		exit( 1 );
+	}
+
+	foreach ( $data['frames'] ?? [] as $frame ) {
+		$elapsed_ms = (int) ( $frame['elapsed_ms'] ?? 0 );
+		$client_id  = (int) ( $frame['client_id'] ?? 0 );
+		$rooms      = $frame['request']['rooms'] ?? [];
+		foreach ( $rooms as $r ) {
+			if ( strpos( $r['room'] ?? '', 'postType/post:' ) === 0 ) {
+				$updates     = $r['updates'] ?? [];
+				$updates_str = implode( ',', array_map( function ( $u ) {
+					return json_encode( $u, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE );
+				}, $updates ) );
+				echo $elapsed_ms . "\t" . $client_id . "\t" . $updates_str . "\n";
+				break;
+			}
+		}
+	}
+}

--- a/rtc-test.sh
+++ b/rtc-test.sh
@@ -1892,48 +1892,9 @@ cmd_capture_sanitize() {
 	local fixture_file="${1:-}"
 	[ -z "${fixture_file}" ] && die "Usage: bash rtc-test.sh capture-sanitize <fixture.json>"
 	[ -f "${fixture_file}" ] || die "File not found: ${fixture_file}"
-	command -v python3 >/dev/null 2>&1 || die "capture-sanitize requires python3"
+	command -v php >/dev/null 2>&1 || die "capture-sanitize requires php"
 
-	python3 -c '
-import json, sys
-
-with open(sys.argv[1]) as f:
-    data = json.load(f)
-
-frames_in  = data.get("frames", [])
-frames_out = []
-for frame in frames_in:
-    rooms = frame.get("request", {}).get("rooms", [])
-    post_room = None
-    for r in rooms:
-        if r.get("room", "").startswith("postType/post:"):
-            post_room = r
-            break
-    if post_room is None:
-        continue
-    frames_out.append({
-        "n":          frame.get("n", len(frames_out) + 1),
-        "elapsed_ms": frame.get("elapsed_ms", 0),
-        "client_id":  frame.get("client_id", 0),
-        "request": {
-            "rooms": [{
-                "room":      "postType/post:0",
-                "client_id": post_room.get("client_id", frame.get("client_id", 0)),
-                "awareness": {},
-                "after":     0,
-                "updates":   post_room.get("updates", [])
-            }]
-        }
-    })
-
-out = {
-    "session_id":  data.get("session_id", ""),
-    "frame_count": len(frames_out),
-    "frames":      frames_out,
-}
-json.dump(out, sys.stdout, separators=(",", ":"))
-sys.stdout.write("\n")
-' "${fixture_file}"
+	php "${SCRIPT_DIR}/rtc-helpers.php" capture-sanitize "${fixture_file}"
 }
 
 # replay FIXTURE_FILE -- replay a captured session JSON against the current RTC endpoint.
@@ -1950,38 +1911,12 @@ cmd_replay() {
 	local fixture_file="${1:-}"
 	[ -z "${fixture_file}" ] && die "Usage: bash rtc-test.sh replay <fixture.json>"
 	[ -f "${fixture_file}" ] || die "File not found: ${fixture_file}"
-	command -v python3 >/dev/null 2>&1 || die "replay requires python3 to parse fixture JSON"
+	command -v php >/dev/null 2>&1 || die "replay requires php to parse fixture JSON"
 
 	local speed="${REPLAY_SPEED:-1}"
 	print_header "replay ($(basename "${fixture_file}"), speed=${speed}x)"
 	require_auth
 
-	# Extract per-frame update payloads from the fixture using python3 -c (no temp file).
-	# Output format (one line per frame): elapsed_ms <TAB> client_id <TAB> updates_json
-	# updates_json is comma-separated {type,data} objects; empty string if no updates.
-	# Only the postType/post:* room is extracted; other rooms (root/comment etc.) skipped.
-	# sys.stdout.flush() after each line prevents Python pipe-buffering from stalling bash.
-	local _py_extractor
-	_py_extractor='
-import json, sys
-try:
-    with open(sys.argv[1]) as f:
-        data = json.load(f)
-except Exception as e:
-    sys.stderr.write("replay: " + str(e) + "\n")
-    sys.exit(1)
-for frame in data.get("frames", []):
-    elapsed_ms = int(frame.get("elapsed_ms", 0))
-    client_id  = frame.get("client_id", 0)
-    rooms      = frame.get("request", {}).get("rooms", [])
-    for r in rooms:
-        if r.get("room", "").startswith("postType/post:"):
-            updates     = r.get("updates", [])
-            updates_str = ",".join(json.dumps(u, separators=(",",":")) for u in updates)
-            sys.stdout.write("{}\t{}\t{}\n".format(elapsed_ms, client_id, updates_str))
-            sys.stdout.flush()
-            break
-'
 
 	local cursor=0
 	local prev_elapsed=0
@@ -2029,7 +1964,7 @@ for frame in data.get("frames", []):
 			"${frame_num}" "${frame_elapsed}" "${ui_count}" "${uo_count}" \
 			"${cursor}" "${total_updates:-0}" "${compact:-false}"
 
-	done < <(python3 -c "${_py_extractor}" "${fixture_file}")
+	done < <(php "${SCRIPT_DIR}/rtc-helpers.php" replay-extract "${fixture_file}")
 
 	if [ "${frame_num}" -eq 0 ]; then
 		printf 'ERROR: no frames extracted. Check fixture format (expected capture-export JSON).\n' >&2


### PR DESCRIPTION
This replaces embedded Python scripts with PHP that can be called from the command line, removing the requirement for `python3` to be installed.