### PR TITLE
Improve object cache detection

### DIFF
--- a/rtc-test.php
+++ b/rtc-test.php
@@ -1042,6 +1042,33 @@ function rtctest_rest_submit( WP_REST_Request $request ) {
 		)
 	);
 
+	$submission_time = gmdate( 'Ymd\THis\Z' );
+	$report_log      = implode(
+		"\n",
+		array(
+			'RTC performance report — submission log',
+			'Submitted at (UTC): ' . $submission_time,
+			'',
+			'------Environment Name-------',
+			'',
+			$environment_name,
+			'',
+			'------Env-------',
+			'',
+			print_r( $env, true ),
+			'',
+			'------Results-------',
+			'',
+			print_r( $results, true ),
+			'',
+			'------Response-------',
+			'',
+			print_r( $response, true ),
+			'',
+		)
+	);
+	file_put_contents( path_join( dirname( __FILE__ ), 'report-submission-' . $submission_time . '.log' ), $report_log );
+
 	if ( is_wp_error( $response ) ) {
 		return new WP_Error( 'submit_failed', $response->get_error_message(), array( 'status' => 502 ) );
 	}

--- a/rtc-test.php
+++ b/rtc-test.php
@@ -879,65 +879,65 @@ function rtctest_rest_report_all( WP_REST_Request $request ) {
 }
 
 function rtctest_detect_object_cache_type() {
-    global $wp_object_cache;
+	global $wp_object_cache;
 
-    // WP's built-in non-persistent in-memory cache.
-    if ( ! wp_using_ext_object_cache() ) {
-        return 'default';
-    }
+	// WP's built-in non-persistent in-memory cache.
+	if ( ! wp_using_ext_object_cache() ) {
+		return 'default';
+	}
 
-    if ( ! isset( $wp_object_cache ) || ! is_object( $wp_object_cache ) ) {
-        return 'ext:unknown';
-    }
+	if ( ! isset( $wp_object_cache ) || ! is_object( $wp_object_cache ) ) {
+		return 'ext:unknown';
+	}
 
-    // Redis Object Cache (rhubarbgroup/redis-cache by Till Krüss).
-    // The drop-in exposes redis_status() whether or not the plugin is active.
-    if ( method_exists( $wp_object_cache, 'redis_status' ) ) {
-        return $wp_object_cache->redis_status() ? 'redis' : 'redis-disconnected';
-    }
+	// Redis Object Cache (rhubarbgroup/redis-cache by Till Krüss).
+	// The drop-in exposes redis_status() whether or not the plugin is active.
+	if ( method_exists( $wp_object_cache, 'redis_status' ) ) {
+		return $wp_object_cache->redis_status() ? 'redis' : 'redis-disconnected';
+	}
 
-    // Object Cache Pro (commercial Redis drop-in).
-    if ( strpos( get_class( $wp_object_cache ), 'RedisCachePro' ) === 0 ) {
-        return 'redis';
-    }
+	// Object Cache Pro (commercial Redis drop-in).
+	if ( strpos( get_class( $wp_object_cache ), 'RedisCachePro' ) === 0 ) {
+		return 'redis';
+	}
 
-    // WP Redis (Pantheon / Human Made / 10up). Different drop-in, same backend.
-    // Uses a $redis property but no redis_status() method.
-    if ( defined( 'WP_REDIS_OBJECT_CACHE' )
-        || ( property_exists( $wp_object_cache, 'redis' ) && isset( $wp_object_cache->redis ) ) ) {
-        return 'redis';
-    }
+	// WP Redis (Pantheon / Human Made / 10up). Different drop-in, same backend.
+	// Uses a $redis property but no redis_status() method.
+	if ( defined( 'WP_REDIS_OBJECT_CACHE' )
+		|| ( property_exists( $wp_object_cache, 'redis' ) && isset( $wp_object_cache->redis ) ) ) {
+		return 'redis';
+	}
 
-    // Memcached drop-in (Automattic / WordPress.com style).
-    // Exposes a public $mc property holding the actual client instance.
-    if ( property_exists( $wp_object_cache, 'mc' ) && isset( $wp_object_cache->mc ) ) {
-        if ( $wp_object_cache->mc instanceof \Memcached ) {
-            return 'memcached';
-        }
-        if ( $wp_object_cache->mc instanceof \Memcache ) {
-            return 'memcache';
-        }
-    }
+	// Memcached drop-in (Automattic / WordPress.com style).
+	// Exposes a public $mc property holding the actual client instance.
+	if ( property_exists( $wp_object_cache, 'mc' ) && isset( $wp_object_cache->mc ) ) {
+		if ( $wp_object_cache->mc instanceof \Memcached ) {
+			return 'memcached';
+		}
+		if ( $wp_object_cache->mc instanceof \Memcache ) {
+			return 'memcache';
+		}
+	}
 
-    // LiteSpeed Cache.
-    if ( strpos( get_class( $wp_object_cache ), 'LiteSpeed' ) !== false ) {
-        return 'litespeed';
-    }
+	// LiteSpeed Cache.
+	if ( strpos( get_class( $wp_object_cache ), 'LiteSpeed' ) !== false ) {
+		return 'litespeed';
+	}
 
-    // W3 Total Cache.
-    if ( method_exists( $wp_object_cache, '_get_engine' )
-        || strpos( get_class( $wp_object_cache ), 'W3TC' ) !== false ) {
-        return 'w3-total-cache';
-    }
+	// W3 Total Cache.
+	if ( method_exists( $wp_object_cache, '_get_engine' )
+		|| strpos( get_class( $wp_object_cache ), 'W3TC' ) !== false ) {
+		return 'w3-total-cache';
+	}
 
-    // APCu drop-in.
-    if ( method_exists( $wp_object_cache, 'apcu_fetch' )
-        || strpos( get_class( $wp_object_cache ), 'APCu' ) !== false ) {
-        return 'apcu';
-    }
+	// APCu drop-in.
+	if ( method_exists( $wp_object_cache, 'apcu_fetch' )
+		|| strpos( get_class( $wp_object_cache ), 'APCu' ) !== false ) {
+		return 'apcu';
+	}
 
-    // Fall back to the actual class name — captures everything else.
-    return 'ext:' . get_class( $wp_object_cache );
+	// Fall back to the actual class name — captures everything else.
+	return 'ext:' . get_class( $wp_object_cache );
 }
 
 function rtctest_get_env() {

--- a/rtc-test.php
+++ b/rtc-test.php
@@ -897,7 +897,7 @@ function rtctest_detect_object_cache_type() {
 	}
 
 	// Object Cache Pro (commercial Redis drop-in).
-	if ( strpos( get_class( $wp_object_cache ), 'RedisCachePro' ) === 0 ) {
+	if ( str_contains( strtolower( get_class( $wp_object_cache ) ), 'redis' ) ) {
 		return 'redis';
 	}
 

--- a/rtc-test.php
+++ b/rtc-test.php
@@ -1071,33 +1071,6 @@ function rtctest_rest_submit( WP_REST_Request $request ) {
 		)
 	);
 
-	$submission_time = gmdate( 'Ymd\THis\Z' );
-	$report_log      = implode(
-		"\n",
-		array(
-			'RTC performance report — submission log',
-			'Submitted at (UTC): ' . $submission_time,
-			'',
-			'------Environment Name-------',
-			'',
-			$environment_name,
-			'',
-			'------Env-------',
-			'',
-			print_r( $env, true ),
-			'',
-			'------Results-------',
-			'',
-			print_r( $results, true ),
-			'',
-			'------Response-------',
-			'',
-			print_r( $response, true ),
-			'',
-		)
-	);
-	file_put_contents( path_join( dirname( __FILE__ ), 'report-submission-' . $submission_time . '.log' ), $report_log );
-
 	if ( is_wp_error( $response ) ) {
 		return new WP_Error( 'submit_failed', $response->get_error_message(), array( 'status' => 502 ) );
 	}

--- a/rtc-test.php
+++ b/rtc-test.php
@@ -879,36 +879,65 @@ function rtctest_rest_report_all( WP_REST_Request $request ) {
 }
 
 function rtctest_detect_object_cache_type() {
-	global $wp_object_cache;
+    global $wp_object_cache;
 
-	if ( ! wp_using_ext_object_cache() ) {
-		return 'default'; // WP's built-in non-persistent in-memory cache.
-	}
+    // WP's built-in non-persistent in-memory cache.
+    if ( ! wp_using_ext_object_cache() ) {
+        return 'default';
+    }
 
-	// Popular Redis drop-ins set one of these constants.
-	if ( defined( 'WP_REDIS_VERSION' ) ) {
-		return 'redis'; // Redis Object Cache plugin (Till Krüss).
-	}
-	if ( defined( 'WP_REDIS_OBJECT_CACHE' ) ) {
-		return 'redis'; // WP Redis (Pantheon / Human Made).
-	}
+    if ( ! isset( $wp_object_cache ) || ! is_object( $wp_object_cache ) ) {
+        return 'ext:unknown';
+    }
 
-	// Memcached drop-in (bundled with WordPress.com / Automattic).
-	if ( defined( 'WP_CACHE_KEY_SALT' ) && class_exists( 'Memcached' ) ) {
-		return 'memcached';
-	}
-	if ( class_exists( 'Memcache' ) ) {
-		return 'memcache';
-	}
+    // Redis Object Cache (rhubarbgroup/redis-cache by Till Krüss).
+    // The drop-in exposes redis_status() whether or not the plugin is active.
+    if ( method_exists( $wp_object_cache, 'redis_status' ) ) {
+        return $wp_object_cache->redis_status() ? 'redis' : 'redis-disconnected';
+    }
 
-	// Fall back to the actual class name — captures everything else.
-	// Note: some drop-ins reuse the class name WP_Object_Cache even for
-	// Redis/Memcached backends, which is why the constant checks come first.
-	if ( isset( $wp_object_cache ) && is_object( $wp_object_cache ) ) {
-		return 'ext:' . get_class( $wp_object_cache );
-	}
+    // Object Cache Pro (commercial Redis drop-in).
+    if ( strpos( get_class( $wp_object_cache ), 'RedisCachePro' ) === 0 ) {
+        return 'redis';
+    }
 
-	return 'ext:unknown';
+    // WP Redis (Pantheon / Human Made / 10up). Different drop-in, same backend.
+    // Uses a $redis property but no redis_status() method.
+    if ( defined( 'WP_REDIS_OBJECT_CACHE' )
+        || ( property_exists( $wp_object_cache, 'redis' ) && isset( $wp_object_cache->redis ) ) ) {
+        return 'redis';
+    }
+
+    // Memcached drop-in (Automattic / WordPress.com style).
+    // Exposes a public $mc property holding the actual client instance.
+    if ( property_exists( $wp_object_cache, 'mc' ) && isset( $wp_object_cache->mc ) ) {
+        if ( $wp_object_cache->mc instanceof \Memcached ) {
+            return 'memcached';
+        }
+        if ( $wp_object_cache->mc instanceof \Memcache ) {
+            return 'memcache';
+        }
+    }
+
+    // LiteSpeed Cache.
+    if ( strpos( get_class( $wp_object_cache ), 'LiteSpeed' ) !== false ) {
+        return 'litespeed';
+    }
+
+    // W3 Total Cache.
+    if ( method_exists( $wp_object_cache, '_get_engine' )
+        || strpos( get_class( $wp_object_cache ), 'W3TC' ) !== false ) {
+        return 'w3-total-cache';
+    }
+
+    // APCu drop-in.
+    if ( method_exists( $wp_object_cache, 'apcu_fetch' )
+        || strpos( get_class( $wp_object_cache ), 'APCu' ) !== false ) {
+        return 'apcu';
+    }
+
+    // Fall back to the actual class name — captures everything else.
+    return 'ext:' . get_class( $wp_object_cache );
 }
 
 function rtctest_get_env() {


### PR DESCRIPTION
This makes a number of improvements to object cache detection to prevent false positives and inaccurate outcomes:

- The `WP_REDIS_VERSION constant is set by a plugin file, not the actual drop-in, so it produces inaccurate results when the drop-in is present but the plugin is deactivated.
- Bare `class_exists('Memcached')` / `class_exists('Memcache')` checks can cause false positives because they only test whether the PHP extension is loaded, not whether it's actually the active cache backend.
- `WP_CACHE_KEY_SALT` is not just a Memcached signal. It's used by multiple drop-ins (including Redis), so should not be used as a reliable indicator.
- Redis detection now uses `method_exists($wp_object_cache, 'redis_status')`. Because this method lives in the drop-in class, it will work regardless of whether the plugin is active.
- Memcached detection now inspects the `$mc` property on the cache object and checks whether it's an actual Memcached or Memcache instance. Prevents false positives when the extension is available but the drop-in is not.
- WP Redis detection still uses `WP_REDIS_OBJECT_CACHE` but now also falls back to a `$redis` property check.
- The `redis-disconnected` return value distinguishes "Redis drop-in installed and connected" from "Redis drop-in installed but silently falling back to in-memory because the server is unreachable."
- Added Object Cache Pro detection.
- Added LiteSpeed Cache detection.
- Added W3 Total Cache detection.
- Added APCu drop-in detection.
- 'ext:unknown' is returned early when $wp_object_cache is not a valid object.